### PR TITLE
Add ExpiringCache

### DIFF
--- a/src/public/New-PSCache.ps1
+++ b/src/public/New-PSCache.ps1
@@ -7,7 +7,7 @@ function New-PSCache {
         [scriptblock]
         $ScriptBlock,
 
-        [Parameter(ParameterSetName = 'Max')]
+        [Parameter(Mandatory, ParameterSetName = 'Max')]
         [ValidateSet('LRU','MRU','LFU')]
         [string]
         $EvictionPolicy,
@@ -16,7 +16,12 @@ function New-PSCache {
         [Alias('MaximumSize')]
         [ValidateRange(2,2147483647)]
         [int]
-        $Capacity = 1000
+        $Capacity = 1000,
+
+        [Parameter(ParameterSetName = 'ExpireAfter')]
+        [ValidateScript({$_ -is [timespan] -or $([timespan]::TryParse($_,[ref]$null))})]
+        [object]
+        $ExpireAfter
     )
 
     $AST = $ScriptBlock.Ast
@@ -45,6 +50,10 @@ function New-PSCache {
         }
 
         return $cacheType::new($ScriptBlock, $Capacity)
+    }
+
+    if($PSCmdlet.ParameterSetName -eq 'ExpireAfter'){
+        
     }
     return [PSObjectCache]::new($ScriptBlock)
 }

--- a/src/public/New-PSCache.ps1
+++ b/src/public/New-PSCache.ps1
@@ -18,9 +18,8 @@ function New-PSCache {
         [int]
         $Capacity = 1000,
 
-        [Parameter(ParameterSetName = 'ExpireAfter')]
-        [ValidateScript({$_ -is [timespan] -or $([timespan]::TryParse($_,[ref]$null))})]
-        [object]
+        [Parameter(Mandatory,ParameterSetName = 'ExpireAfter')]
+        [timespan]
         $ExpireAfter
     )
 
@@ -53,7 +52,7 @@ function New-PSCache {
     }
 
     if($PSCmdlet.ParameterSetName -eq 'ExpireAfter'){
-        
+        return [ExpiringCache]::new($ScriptBlock, $ExpireAfter)
     }
     return [PSObjectCache]::new($ScriptBlock)
 }

--- a/test/LFUCache.Tests.ps1
+++ b/test/LFUCache.Tests.ps1
@@ -1,12 +1,12 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='SuppressImportModule')]
-$SuppressImportModule = $true
+$SuppressImportModule = $false
 . $PSScriptRoot\Shared.ps1
 
 Describe 'New-PSCache works with LRU Policy' {
     It 'Returns a PSObjectCache object' {
         (New-PSCache -ScriptBlock {
 
-        } -EvictionPolicy LFU).GetType().FullName |Should Be LFUCache
+        } -EvictionPolicy LFU).GetType().FullName |Should -Be LFUCache
     }
 
     It 'Evicts Least-Frequently Used entries' {
@@ -17,10 +17,10 @@ Describe 'New-PSCache works with LRU Policy' {
 
         # Two over capacity, cache should evict 2, then 3 (least recently promoted among the least frequently hit (2,3,4))
         $EntryKeys = $LFUCache.LookupTable.Values.Value.Key |Sort-Object 
-        $EntryKeys[0] |Should Be 1
-        $EntryKeys[1] |Should Be 4
-        $EntryKeys[2] |Should Be 5
-        $LFUCache.LookupTable.ContainsKey(2) |Should Be $false
-        $LFUCache.LookupTable.ContainsKey(3) |Should Be $false
+        $EntryKeys[0] |Should -Be 1
+        $EntryKeys[1] |Should -Be 4
+        $EntryKeys[2] |Should -Be 5
+        $LFUCache.LookupTable.ContainsKey(2) |Should -BeFalse
+        $LFUCache.LookupTable.ContainsKey(3) |Should -BeFalse
     }
 }

--- a/test/LRUCache.Tests.ps1
+++ b/test/LRUCache.Tests.ps1
@@ -1,12 +1,12 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='SuppressImportModule')]
-$SuppressImportModule = $true
+$SuppressImportModule = $false
 . $PSScriptRoot\Shared.ps1
 
 Describe 'New-PSCache works with LRU Policy' {
     It 'Returns a PSObjectCache object' {
         (New-PSCache -ScriptBlock {
 
-        } -EvictionPolicy LRU).GetType().FullName |Should Be LRUCache
+        } -EvictionPolicy LRU).GetType().FullName |Should -Be LRUCache
     }
 
     It 'Evicts Least-Recently Used entries' {
@@ -16,7 +16,7 @@ Describe 'New-PSCache works with LRU Policy' {
         }
 
         # One over capacity, cache should evict 1 (least recently promoted)
-        $LRUCache.Entries.First.Value.Key |Should Be 4
-        $LRUCache.LookupTable.ContainsKey(1) |Should Be $false
+        $LRUCache.Entries.First.Value.Key |Should -Be 4
+        $LRUCache.LookupTable.ContainsKey(1) |Should -BeFalse
     }
 }

--- a/test/MRUCache.Tests.ps1
+++ b/test/MRUCache.Tests.ps1
@@ -1,12 +1,12 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='SuppressImportModule')]
-$SuppressImportModule = $true
+$SuppressImportModule = $false
 . $PSScriptRoot\Shared.ps1
 
 Describe 'New-PSCache works with MRU Policy' {
     It 'Returns a PSObjectCache object' {
         (New-PSCache -ScriptBlock {
 
-        } -EvictionPolicy MRU).GetType().FullName |Should Be MRUCache
+        } -EvictionPolicy MRU).GetType().FullName |Should -Be MRUCache
     }
 
     It 'Evicts Most-Recently Used entries' {
@@ -16,7 +16,7 @@ Describe 'New-PSCache works with MRU Policy' {
         }
 
         # One over capacity, cache should evict 3 (most recently promoted before 4)
-        $MRUCache.Entries.First.Value.Key |Should Be 4
-        $MRUCache.LookupTable.ContainsKey(3) |Should Be $false
+        $MRUCache.Entries.First.Value.Key |Should -Be 4
+        $MRUCache.LookupTable.ContainsKey(3) |Should -Be $false
     }
 }

--- a/test/PSCache.Tests.ps1
+++ b/test/PSCache.Tests.ps1
@@ -46,14 +46,14 @@ Describe 'New-PSCache supports timed expiration' {
     It 'Evicts after expiration elapses' {
         $ExpiringCache = New-PSCache -ScriptBlock {
             return Get-Date
-        } -ExpireAfter (New-TimeSpan -Seconds 5)
+        } -ExpireAfter (New-TimeSpan -Seconds 2)
 
         $first = $ExpiringCache.Get(1)
         $second = $ExpiringCache.Get(1)
 
         $first -eq $second |Should -BeTrue
 
-        Start-Sleep -Seconds 5
+        Start-Sleep -Seconds 2
         $third = $ExpiringCache.Get(1)
         $second -eq $third |Should -BeFalse
     }

--- a/test/PSCache.Tests.ps1
+++ b/test/PSCache.Tests.ps1
@@ -1,11 +1,13 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='SuppressImportModule')]
-$SuppressImportModule = $true
+$SuppressImportModule = $false
 . $PSScriptRoot\Shared.ps1
 
 Describe 'Module Manifest Tests' {
     It 'Passes Test-ModuleManifest' {
+        $ModuleManifestName = 'PSCache.psd1'
+        $ModuleManifestPath = "$PSScriptRoot\..\src\$ModuleManifestName"
         Test-ModuleManifest -Path $ModuleManifestPath
-        $? | Should Be $true
+        $? | Should -BeTrue
     }
 }
 
@@ -13,7 +15,7 @@ Describe 'New-PSCache works' {
     It 'Returns a PSObjectCache object' {
         (New-PSCache -ScriptBlock {
 
-        }).GetType().FullName |Should Be PSObjectCache
+        }).GetType().FullName |Should -Be PSObjectCache
     }
 
     It 'Accepts fetchers with 1 parameter' {
@@ -21,7 +23,7 @@ Describe 'New-PSCache works' {
             New-PSCache -ScriptBlock {
                 param($a)
             }
-        } |Should Not Throw
+        } |Should -Not -Throw
     } 
 
     It 'Rejects fetchers with multiple params' {
@@ -29,13 +31,30 @@ Describe 'New-PSCache works' {
             New-PSCache -ScriptBlock {
                 param($a,$b)
             }
-        } |Should Throw
+        } |Should -Throw
     }
 
     It 'Supports $_' {
         $MirrorCache = New-PSCache -ScriptBlock {
             return $_
         }
-        $MirrorCache.Get(1) |Should Be 1
+        $MirrorCache.Get(1) |Should -Be 1
+    }
+}
+
+Describe 'New-PSCache supports timed expiration' {
+    It 'Evicts after expiration elapses' {
+        $ExpiringCache = New-PSCache -ScriptBlock {
+            return Get-Date
+        } -ExpireAfter (New-TimeSpan -Seconds 5)
+
+        $first = $ExpiringCache.Get(1)
+        $second = $ExpiringCache.Get(1)
+
+        $first -eq $second |Should -BeTrue
+
+        Start-Sleep -Seconds 5
+        $third = $ExpiringCache.Get(1)
+        $second -eq $third |Should -BeFalse
     }
 }


### PR DESCRIPTION
This adds basic support for time-based per-item expiration:

```powershell
$expiringDateCache = New-PSCache { Get-Date } -ExpireAfter (New-TimeSpan -Seconds 5)

# These will receive the same copy
$firstMiss = $expiringDateCache.Get(1)
$firstHit = $expiringDateCache.Get(1)

Start-Sleep -Seconds 5

# This will get a new one
$firstExpiration = $expiringDateCache.Get(1)
```

This might be useful in situations where repeated random access in a tight loop is undesirable, but where the cached information is volatile:

```powershell
function Trace-Connections {
  param([string]$ProcessOwner = $env:USERNAME)
  
  $processOwnerMaxAge = New-TimeSpan -Seconds 5
  $processOwnerCache = New-PSCache { Get-Process -Id $_ -IncludeUserName |% UserName } -ExpireAfter $processOwnerMaxAge

  while($true){
    Get-NetTCPConnection |Where-Object {$processOwnerCache[[int]$_.OwningProcess] -eq $ProcessOwner} |Select Local*,Remote*,@{Name='Timestamp';Expression={Get-Date}}
  }
}
```